### PR TITLE
support build behind proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Xu Wang <xuwang@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install build-essential, ruby, and nodejs, etc.
-# Also install docker.io, which necessary only 
+# Also install docker.io, which necessary only
 # when host os is not same as the base image of this Dockerfile
 RUN echo 'deb http://http.debian.net/debian jessie-backports main' >> /etc/apt/sources.list \
     && apt-get update \

--- a/build.sh
+++ b/build.sh
@@ -5,17 +5,23 @@ REPO=${1:-github.com/purpleworks/fleet-ui}
 # First build the fleet-ui-builder image
 echo building fleet-ui-builder ...
 docker rmi fleet-ui-builder:latest > /dev/null 2>&1
-docker build -t fleet-ui-builder .
+if [ -z "${http_proxy}" ]; then
+  docker build -t fleet-ui-builder .
+else
+  docker build --build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy} -t fleet-ui-builder .
+fi
 
 # Run the builder image to build fleet-ui docker image
 echo building fleet-ui ...
 docker rmi fleet-ui:latest > /dev/null 2>&1
 docker run -t --rm \
-	-v /var/run/docker.sock:/var/run/docker.sock \
-	--env FLEET_VERSION=v0.11.5 \
-	--env FLEETUIREPO=$REPO \
-	--dns 8.8.8.8 \
-	fleet-ui-builder:latest
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  --env FLEET_VERSION=v0.11.5 \
+  --env FLEETUIREPO=$REPO \
+  --env http_proxy=${http_proxy} \
+  --env https_proxy=${https_proxy} \
+  --dns 8.8.8.8 \
+  fleet-ui-builder:latest
 
 # Show the build result
 docker images fleet-ui


### PR DESCRIPTION
In order to build behind proxy, you need to add `--build-arg` for `http_proxy` and `https_proxy`
